### PR TITLE
Fix setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-torch
-argbind>=0.3.2
-numpy==1.22
-gradio
-loralib
-wavebeat @ git+https://github.com/hugofloresgarcia/wavebeat
-lac @ git+https://github.com/hugofloresgarcia/lac.git
-descript-audiotools @ git+https://github.com/descriptinc/audiotools.git@0.7.2

--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,14 @@ setup(
     install_requires=[
         "torch",
         "argbind>=0.3.2",
-        "numpy==1.22",
+        "numpy==1.23",
         "wavebeat @ git+https://github.com/hugofloresgarcia/wavebeat",
         "lac @ git+https://github.com/hugofloresgarcia/lac.git",
         "descript-audiotools @ git+https://github.com/descriptinc/audiotools.git@0.7.2",
         "gradio", 
         "tensorboardX",
         "loralib",
+        "torch_pitch_shift",
+        "madmom",
     ],
 )


### PR DESCRIPTION
Currently, the app will not run if following the instructions in the readme. This is because of issues with `setup.py`:

1. `numpy==1.22` is listed, but only `numpy==1.23` works due to constraints from `Numba` and `madmom`.
2. `madmom` and `torch_pitch_shift` are missing from `install_requires` kwarg.

This PR fixes these issues. Additionally, it removes `requirements.txt`, since this file is not used during installation and is currently a redundant copy of the information found in the `install_requires` kwarg in `setup.py`. This change is not necessary to get things working again, but I think it is the right thing to do. (More on the difference between `requirements.txt` and `install_requires` in [this StackOverflow issue](https://stackoverflow.com/questions/14399534/reference-requirements-txt-for-the-install-requires-kwarg-in-setuptools-setup-py).)

This resolves issue https://github.com/hugofloresgarcia/vampnet/issues/14

I confirmed that with these changes, following the instructions in the readme will now allow the user to run a minimal example (the default presets on the example audio file) with no errors. Tested on a `g4` instance on AWS.