### PR TITLE
Script to write examples-table html file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ notebooks/*.mp4
 *runs/
 boards/
 samples/
+examples/
 *.ipynb
 
 results.json
@@ -159,6 +160,7 @@ mprofile*
 env.sh
 _codebraid/
 **/*.html
+!templates/*.html
 **/*.exec.md
 flagged/
 log.txt

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ license: cc-by-nc-4.0
 
 ## setting up
 
-python 3.9-3.11 works well. (for example, using conda)
+python 3.10-3.11 works well. (for example, using conda)
 ```bash
-conda create -n vampnet python=3.9
+conda create -n vampnet python=3.10
 conda activate vampnet
 ```
 

--- a/scripts/utils/write_examples_table.py
+++ b/scripts/utils/write_examples_table.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+ROOT_DIR = Path(__file__).parent.parent.parent
+EXAMPLES_DIR = ROOT_DIR / "examples"
+TEMPLATE_DIR = ROOT_DIR / "templates"
+HTML_FILE = ROOT_DIR / "audio_examples.html"
+TEMPLATE_FILENAME = "examples_table_template.html"
+
+experiments = sorted([d.name for d in EXAMPLES_DIR.iterdir() if d.is_dir()])
+
+# Prepare data for template
+all_sounds = set() # denotes the rows of the table
+for exp in experiments:
+    exp_dir = EXAMPLES_DIR / exp
+    sounds = [f.name for f in exp_dir.iterdir() if f.suffix == '.wav']
+    all_sounds.update(sounds)
+sounds = sorted(all_sounds)
+
+audio_exists = {exp: {} for exp in experiments}
+for exp in experiments:
+    for sound in sounds:
+        path = EXAMPLES_DIR / exp / sound
+        if path.exists():
+            audio_exists[exp][sound] = str(path)
+        else:
+            audio_exists[exp][sound] = None
+
+# Render HTML file
+env = Environment(
+    loader=FileSystemLoader(str(TEMPLATE_DIR)),
+    autoescape=select_autoescape(['html'])
+)
+template = env.get_template(TEMPLATE_FILENAME)
+
+html = template.render(
+    experiments=experiments,
+    sounds=sounds,
+    audio_exists=audio_exists
+)
+
+with open(HTML_FILE, "w") as f:
+    f.write(html)
+
+print(f"HTML file written to {HTML_FILE}")

--- a/templates/examples_table_template.html
+++ b/templates/examples_table_template.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Examples Table</title>
+    <style>
+        table { border-collapse: collapse; }
+        th, td { border: 1px solid #aaa; padding: 8px; }
+        th { background-color: #f2f2f2; }
+        audio { width: 180px; }
+    </style>
+</head>
+<body>
+    <h1>Generated Examples</h1>
+    <table>
+        <tr>
+            <th>Sound</th>
+            {% for experiment in experiments %}
+                <th>{{ experiment }}</th>
+            {% endfor %}
+        </tr>
+        {% for sound in sounds %}
+        <tr>
+            <td>{{ sound }}</td>
+            {% for experiment in experiments %}
+                <td>
+                    {% if audio_exists[experiment][sound] %}
+                        <audio controls>
+                            <source src="{{ audio_exists[experiment][sound] }}" type="audio/wav">
+                            Your browser does not support the audio element.
+                        </audio>
+                    {% else %}
+                        N/A
+                    {% endif %}
+                </td>
+            {% endfor %}
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Overview

Add a script that creates a simple html table for organizing generated examples by experiments.

Also, using python 3.9 yields dependency issues, mainly because pyharp requires `gradio==5.28.0`, which is only available from python `>= 3.10`. Updated README accordingly

## Script Usage

From an `examples` dir, organized into different experiments, e.g.

```
./examples/
    exp1/
        sound1.wav
        sound2.wav
    exp2/
        sound1.wav
        sound2.wav
    exp3/
        sound3.wav
```

The scripts uses a jinja template to write the html file.

## Test Table

[Screen recording](https://drive.google.com/file/d/1DAXMn9tUghN5CinCQmZlXUWsE2XYs3mC/view?usp=drive_link)

Forgot to record audio, sorry about that, trust me that it works tho.

[Link to examples dir used as input](https://drive.google.com/drive/folders/1FF8pGgpMfP1LqM94PeSGZL9bO-vShlED?usp=drive_link)




